### PR TITLE
Add Option to copy the original file's modified date onto the copied files

### DIFF
--- a/consts/consts.go
+++ b/consts/consts.go
@@ -5,4 +5,6 @@ const (
 	DEFAULT_OUTPUT_DIR = "./output"
 
 	SHORT_INPUT_DIR = "i"
+
+	RETAIN_MODIFIED_DATE = "d"
 )

--- a/duplicate-file-remover.go
+++ b/duplicate-file-remover.go
@@ -13,6 +13,7 @@ func main() {
 	var argList argument_list.ArgumentList
 	flag.Var(&argList, consts.SHORT_INPUT_DIR, "Input directories, please provide the flag multiple times for as many input directories as you require.")
 	shortOutputDir := flag.String(consts.SHORT_OUTPUT_DIR, consts.DEFAULT_OUTPUT_DIR, "Output directory")
+	retainModifiedTime := flag.Bool(consts.RETAIN_MODIFIED_DATE, false, "Retains the modified date of the original file in the copied destination files. This can be required if you wish the output files modified date to match that of the original file.")
 
 	flag.Parse()
 
@@ -29,7 +30,7 @@ func main() {
 		return
 	}
 
-	err = files.MergeFileDirs(argList.Args, *shortOutputDir)
+	err = files.MergeFileDirs(argList.Args, *shortOutputDir, *retainModifiedTime)
 	if err != nil {
 		fmt.Printf("Error encountered. %s\n", err.Error())
 	}


### PR DESCRIPTION
Add flag "-d" that will retain the modification date of the copied files so that it matches the original file that was copied.

Also used filepath.Join() in places where applicable.